### PR TITLE
add pq.el and move pq.c -> pq-core.c

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,20 @@
 EMACS = emacs
+EMACS_VERSION := $(shell $(EMACS) -q --batch --eval "(princ emacs-version)")
+EMACS_MAJOR_VERSION := $(shell $(EMACS) -q --batch --eval "(princ emacs-major-version)")
+EMACS_INCLUDE_DIR := $(wildcard /usr/include/emacs-$(EMACS_MAJOR_VERSION)*)
+EMACS_SRC_DIR := /usr/share/emacs/$(EMACS_VERSION)
 
 PG_CONFIG = pg_config
 PGINCLUDEDIR := $(shell $(PG_CONFIG) --includedir)
 
 CC = gcc
-CFLAGS  = -I$(CURDIR) -I$(HOME)/ext/emacs/src/ -I$(PGINCLUDEDIR) -std=gnu99 -ggdb3 -Wall -fPIC
+CFLAGS  = -I$(CURDIR) -I$(EMACS_INCLUDE_DIR) -I$(EMACS_SRC_DIR) -I$(PGINCLUDEDIR) -std=gnu99 -ggdb3 -Wall -fPIC
 LDFLAGS = -lpq
 
 ifeq ($(OS),Windows_NT)
-TARGET = pq.dll
+TARGET = pq-core.dll
 else
-TARGET = pq.so
+TARGET = pq-core.so
 endif
 
 all: $(TARGET)

--- a/pq-core.c
+++ b/pq-core.c
@@ -452,7 +452,7 @@ emacs_module_init (struct emacs_runtime *ert)
        env->funcall(env, Fdefine_error, 2, args);
   }
 
-  provide(env, "pq");
+  provide(env, "pq-core");
 
   /* loaded successfully */
   return 0;

--- a/pq.el
+++ b/pq.el
@@ -1,0 +1,32 @@
+;;; pq.el --- libpq binding
+
+;; Copyright (C) 2020 by Tom Gillespie
+
+;; Author: Tom Gillespie
+;; URL: https://github.com/tgbugs/emacs-libpq
+;; Version: 0.01
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; An almost completely empty wrapper to simplify packaging on *elpa.
+
+;;; Code:
+
+(require 'pq-core)
+
+(provide 'pq)
+
+;;; pq.el ends here


### PR DESCRIPTION
The objective of this is to keep *elpa packaging systems happy by having
an elisp file that matches the name of the package.

Also updated the Makefile to use emacs to get the version and look for
emacs-module.h in /usr/share/emacs/${emacs-version}/src/ and in
/usr/include/emacs-${emacs-major-version}-*/.

In principle these are steps toward being able to distribute via some *elpa (these changes were to get it working with quelpa). More changes would be needed to support an installation experience similar to that of emacs-libvterm (for example), but at least all the files needed to run `make` manually would be in place.