### PR TITLE
pq.el: improvements for packaging

### DIFF
--- a/pq-core.c
+++ b/pq-core.c
@@ -1,3 +1,20 @@
+/* libpq bindings for Emacs Lisp as a dynamic module
+   Copyright (C) 2020-2022 Free Software Foundation, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or (at
+your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
+
+
 #include <emacs-module.h>
 #include <libpq-fe.h>
 #include "pg_type.h"

--- a/pq.el
+++ b/pq.el
@@ -1,6 +1,6 @@
 ;;; pq.el --- libpq binding
 
-;; Copyright (C) 2020 by Tom Gillespie
+;; Copyright (C) 2020-2022  Free Software Foundation, Inc.
 
 ;; Author: Tom Gillespie
 ;; URL: https://github.com/anse1/emacs-libpq

--- a/pq.el
+++ b/pq.el
@@ -3,8 +3,9 @@
 ;; Copyright (C) 2020 by Tom Gillespie
 
 ;; Author: Tom Gillespie
-;; URL: https://github.com/tgbugs/emacs-libpq
+;; URL: https://github.com/anse1/emacs-libpq
 ;; Version: 0.01
+;; Package-Requires: ((emacs "25"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -25,7 +26,7 @@
 
 ;;; Code:
 
-(require 'pq-core)
+(if t (require 'pq-core))
 
 (provide 'pq)
 


### PR DESCRIPTION
make the repository of record clear

add package requires for emacs 25

wrap require 'pq-core in (if t ...) to keep the compiler happy
since pq-core is the c module that will be missing at compile

re: https://github.com/anse1/emacs-libpq/issues/12#issuecomment-1039545993