### PR TITLE
Update README.org : test.el renamed to pq-test.el

### DIFF
--- a/README.org
+++ b/README.org
@@ -73,6 +73,6 @@ does not allow for asynchronous callbacks, you have to check for these
 periodically after a =LISTEN= statement by calling =pq:notifies=.
 Calling it will not cause any traffic on the connection itself.
 
-See the testsuite [[./test.el]] for more implemented features.
+See the testsuite [[./pq-test.el]] for more implemented features.
 
 [[https://api.travis-ci.org/anse1/emacs-libpq.svg]]


### PR DESCRIPTION
I suppose `test.el` must hae been renamed to `pq-test.el` without  README.org being updated.